### PR TITLE
Added target attribute to header and footer links

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,7 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added target attribute to header and footer link [pnicolli]
 
 
 1.3.3 (2014-12-11)

--- a/rer/portlet/advanced_static/rerportletadvancedstatic.pt
+++ b/rer/portlet/advanced_static/rerportletadvancedstatic.pt
@@ -6,7 +6,8 @@
 	 
 <dl tal:condition="not:view/data/omit_border"
     tal:attributes="class view/getPortletClass"
-    tal:define="portlet_link view/getPortletLink"
+    tal:define="portlet_link view/getPortletLink;
+                link_target python:view.hasInternalLink() and '_self' or '_blank'"
     i18n:domain="rer.portlet.advanced_static">
 
     <dt class="portletHeader">
@@ -17,7 +18,7 @@
         </span>
         <span class="portletTopLeft"></span>
         <a class="tile" tal:condition="portlet_link"
-		   tal:attributes="href portlet_link">
+		   tal:attributes="href portlet_link;target link_target">
         	<span tal:content="view/data/header"></span>
         </a>
 		<span class="tile"
@@ -37,7 +38,7 @@
     <dd class="portletFooter" tal:condition="view/has_footer">
         <span class="portletBottomLeft"></span>
         <span tal:condition="portlet_link">
-           <a tal:attributes="href portlet_link"
+           <a tal:attributes="href portlet_link;target link_target"
               tal:content="view/data/footer"
               />
         </span>

--- a/rer/portlet/advanced_static/rerportletadvancedstatic.py
+++ b/rer/portlet/advanced_static/rerportletadvancedstatic.py
@@ -212,6 +212,12 @@ class Renderer(static.Renderer):
         else:
             return self.data.more_url or ""
 
+    def hasInternalLink(self):
+        if self.data.internal_url:
+            return True
+        else:
+            return False
+
 
 class AddForm(static.AddForm):
     """Portlet add form.


### PR DESCRIPTION
Added a target attribute to header and footer link, that is equal to "_blank" when the external link field is used as href.
