### PR TITLE
Added compatibility for dexterity background images

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added compatibility with dexterity images used as background images [pnicolli]
 
 
 1.4.0 (2016-02-26)

--- a/rer/portlet/advanced_static/rerportletadvancedstatic.py
+++ b/rer/portlet/advanced_static/rerportletadvancedstatic.py
@@ -144,6 +144,10 @@ class Renderer(static.Renderer):
         image = self.getImageObject(self.data.image_ref)
         if not image:
             return ""
+        # compatibility with dexterity images
+        blobimage = getattr(image, 'image', None)
+        if blobimage:
+            return blobimage.getImageSize()[1]
         return str(image.getImage().height)
 
     def getImageStyle(self):


### PR DESCRIPTION
This adds compatibility with Dexterity images from plone.app.contenttypes to be used in the Background Image field.