### PR TITLE
CI: Fix lxml compilation on Python 2, Plone 5.0.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
     steps:
+      - name: Install lxml compilation dependencies, needed for Plone 5.0
+        if: {{ python-version == "2.7" }}
+        run: |
+            sudo apt-get update
+            sudo apt-get install libxml2-dev libxslt1-dev
       - name: Test Py ${{ matrix.python-version }}
         uses: collective/tox-action@main
         with:


### PR DESCRIPTION
Worked fine without this in my original PR, but on master it failed.